### PR TITLE
Feedback

### DIFF
--- a/feedback/env-anywhere-def.R
+++ b/feedback/env-anywhere-def.R
@@ -1,0 +1,25 @@
+#' which parent environments of <env> contain <name>?
+#' inputs:
+#'    name: a variable name
+#'    env: valid inputs for pryr:::to_env, defaults to the calling frame
+#' output: a list of environments containing <name>
+anywhere <- function(name, env = parent.frame()) {
+  checkmate::assert_string(name, min.chars = 1)
+  #to_env takes care of checks for <env> and conversions to environments
+  # (input checking & homogenization)
+  env <- pryr:::to_env(env)
+
+  result <- list()
+  # base case: terminate recursion in emptyenv and return empty list
+  if (identical(env, emptyenv())) {
+    return(list())
+  }
+  # success: if <name> is in current <env>, <env> is added to results list ...
+  if (exists(name, env, inherits = FALSE)) {
+    result <- append(result, env)
+  }
+  # .... and then we go up one level to the next environment and add what we
+  #      find there to the list
+  # (recursion)
+  append(result, anywhere(name, parent.env(env)))
+}

--- a/feedback/env-sol.Rmd
+++ b/feedback/env-sol.Rmd
@@ -1,0 +1,56 @@
+<!--
+Knitten Sie dieses File in RStudio zur besseren Lesbarkeit, bitte...
+-->
+
+```{r, child = "env-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+a) 
+
+* alle Objekte in `environment` müssen Namen haben, Listen können unbenamte Einträge haben.
+* Objekte in einem `environment` haben keine Reihenfolge/Topologie, Einträge in einer Liste schon.
+* Jedes `environment` hat eine Elternumgebung
+* `environment`s haben *reference semantics*: D.h. das im `environment` hinterlegte *binding* eines Symbols (also: des Namens einer Variable) an einen Wert wird nur über den Speicherort dieses Werts repräsentiert (also: ein bestimmtes Symbol verweist auf -- *referenziert* -- eine Adresse im Speicher). Das heißt:
+    - ein und das selbe Objekt/der selbe Wert kann Element mehrer `environments` sein, unter möglicherweise unterschiedlichen Namen die aber eben alle den selben Speicherort referenzieren! 
+    - Modifikation eines `environment` erzeugt keine Kopie der im `environment` an Symbole gebundenen Werte (also: kein *copy-on-modify* wie bei anderen R Objekten).
+
+b) 
+
+In der Umgebung aus der sie aufgerufen wurden, siehe `?ls` bzw. `?rm`.
+
+c) 
+
+Siehe `help("<-"), help("<<-")`. 
+
+`<-` legt eine neue `binding` (eine Verknüpfung zwischen einem Symbol für eine Variable und dem Speicherort wo der Wert der Variable ) in der Umgebung in der `<-` aufgerufen wurde an, bzw. ersetzt eine alte Zuweisung für die Variable auf der linken Seite. 
+
+Das Verhalten von `<<-` hängt davon ab ob/wo eine Variable durch das Symbol auf der linken Seite bereits definiert ist. Falls die Variable in der aufrufenden Umgebung nicht definiert ist, sucht `<<-` die Vorfahrenumgebungen der aufrufenden Umgebung ab und ersetzt die Zuweisung in der ersten Vorfahrenumgebung in der die Variable definiert ist. Ist sie nirgends definiert (oder bereits bestehende `binding`s sind `locked`, also nicht überschreibbar) so wird eine neue Variable im `.GlobalEnv` angelegt.
+
+d)
+
+Mit Rekursion (Funktion `anywhere()` ruft sich immer wieder selbst auf):
+```{r, def_anywhere, code = readLines("env-anywhere-def.R"), echo = FALSE}
+```
+Äquivalent ohne Rekursion:
+```{r, def_anywhere_sequential, eval=FALSE}
+anywhere <- function(name, env = parent.frame()) {
+  checkmate::assert_string(name)
+  env <- pryr:::to_env(env)
+  result <- list()
+  while (!identical(env, emptyenv())) {
+    if (exists(name, env, inherits = FALSE)) {
+      result <- append(result, env)
+    }
+    env <- parent.env(env)
+  }
+  result
+}
+```
+
+```{r, test-anywhere, eval = TRUE, code=readLines("test-env-anywhere.R")}
+```
+Sie fragen vielleicht warum hier auch eine Variable "`t`" gefunden wird, die in der Umgebung, die mit dem `base`-Paket assoziiert ist, liegt...? Da haben wir doch gar nix angelegt...? Das ist die Funktion mit der Matrizen und Vektoren transponiert werden! 


### PR DESCRIPTION
@marquach

Gut gemacht! 

Pingelige Detailkritik:

- https://github.com/fort-w2021/env-ex-marquach/blob/01a18b64af09aa2e2fbffdfd711dbb58adea0417/env-ex.Rmd#L8
vgl auch Musterlösung bzw Literatur zu *reference semantics* -- wichtig dass sie verstehen *warum* `environment`s sich so verhalten. 

- https://github.com/fort-w2021/env-ex-marquach/blob/01a18b64af09aa2e2fbffdfd711dbb58adea0417/env-ex.Rmd#L22
Mmjoah, denke schon, kommt drauf an. Das könnte tatsächlich eine Idee für einen halbwegs sinnvollen use case von `<<-` sein...

- https://github.com/fort-w2021/env-ex-marquach/blob/01a18b64af09aa2e2fbffdfd711dbb58adea0417/env-ex.Rmd#L34
besten dank! :smiley: 

- https://github.com/fort-w2021/env-ex-marquach/blob/01a18b64af09aa2e2fbffdfd711dbb58adea0417/env-ex.Rmd#L39-L41
funktioniert, lesbarer wäre `repeat` statt `while(TRUE)`,  noch deutlich besser, weil kürzer und direkter:   
halt einfach `while(!identical(env, emptyenv()))` 

- https://github.com/fort-w2021/env-ex-marquach/blob/01a18b64af09aa2e2fbffdfd711dbb58adea0417/env-ex.Rmd#L47
diesen if-block könnte man sich sparen, da der code in dem if-Block nur erreicht werden kann falls die aktuelle iteration nicht durch die 2 if-blöcke davor eh schon unterbrochen wurde und IMMER falls die iteration nicht unterbrochen wurde dieser code ausgeführt werden muss. also kann er raus aus seinem `if`-Käfig.  
smell: *conditional complexity* mit aroma "überflüssiges else" (denn die if bedingung als logisches gegenteil zur if bedingung direkt darüber zu formulieren ist äquivalent zu `else`).
generelles pattern: kein `else` nach if-Block mit `stop, return, break` oder `next` (wir hatten das bisher explizit nur für `stop`und `return` erwähnt, aber die idee ist die selbe....)

- https://github.com/fort-w2021/env-ex-marquach/blob/01a18b64af09aa2e2fbffdfd711dbb58adea0417/env-ex.Rmd#L33
bitte *immer* kommentarzeile "was tut das? was kriegt's? was gibt's raus?" über jede funktion....